### PR TITLE
fix(neotest): remove unecessary mappings

### DIFF
--- a/lua/config/keymaps/test-keys.lua
+++ b/lua/config/keymaps/test-keys.lua
@@ -2,12 +2,4 @@ return function(map)
   map("n", "<leader>tp", function()
     vim.cmd("w | PlenaryBustedFile %")
   end)
-
-  map("n", "<leader>tn", function()
-    vim.cmd("w | Neotest run")
-  end)
-
-  map("n", "<leader>ts", function()
-    vim.cmd("w | Neotest summary")
-  end)
 end


### PR DESCRIPTION
I think these were added as default keybindings to neotest and now neotest has some kind of lazy hydration, so these keybindings will actually fail to run.

Fixes N/A